### PR TITLE
feature: -v for version (from git tag)  #23

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.tag_name export-subst

--- a/.tag_name
+++ b/.tag_name
@@ -1,0 +1,1 @@
+$Format:%(describe:tags=true)$

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: reredirect
 
 .PHONY: .force
 # Get version from git
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null || echo "0.1-unknown")
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null || cat .tag_name)
 
 version.h: .force
 	@VERSION_CONTENT='#define REREDIRECT_VERSION "$(GIT_VERSION)"'; \

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,22 @@ PREFIX=/usr/local
 
 all: reredirect
 
+.PHONY: .force
+# Get version from git
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null || echo "0.1-unknown")
+
+version.h: .force
+	@VERSION_CONTENT='#define REREDIRECT_VERSION "$(GIT_VERSION)"'; \
+	EXISTING_CONTENT="$$(cat $@)"; \
+	if [ "$$EXISTING_CONTENT" != "$$VERSION_CONTENT" ]; then \
+		echo "$$VERSION_CONTENT" > $@; \
+		echo "Version updated to $(GIT_VERSION)"; \
+	fi
+
 reredirect: $(OBJS)
 
 attach.o: reredirect.h ptrace.h
-reredirect.o: reredirect.h
+reredirect.o: reredirect.h version.h
 ptrace.o: ptrace.h $(wildcard arch/*.h)
 
 clean:

--- a/reredirect.c
+++ b/reredirect.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
     unsigned long scratch_page = (unsigned long) -1;
     struct ptrace_child child;
 
-    while ((opt = getopt(argc, argv, "m:i:o:e:I:O:E:s:dNvh")) != -1) {
+    while ((opt = getopt(argc, argv, "m:i:o:e:I:O:E:s:dNvVh")) != -1) {
         switch (opt) {
             case 'I':
                 if (filei || fdi >= 0)

--- a/reredirect.h
+++ b/reredirect.h
@@ -21,8 +21,7 @@
  * THE SOFTWARE.
  */
 #include "ptrace.h"
-
-#define REREDIRECT_VERSION "0.1"
+#include "version.h"
 
 int child_attach(pid_t pid, struct ptrace_child *child, child_addr_t *scratch_page);
 int child_detach(struct ptrace_child *child, child_addr_t scratch_page);


### PR DESCRIPTION
for #23 

enable the `-V` args to show reredirect version.

generate version from
- `git describe --abbrev=4 --dirty --always --tags` if work in git repo
- `cat .tag_name` if not in git repo, as fallback (the .tar.gz/.zip generated by github)

